### PR TITLE
Edit boxers selector

### DIFF
--- a/client/src/app.vue
+++ b/client/src/app.vue
@@ -42,7 +42,7 @@ export default defineComponent({
             () => [tournamentStore.currentTournamentId],
             async () => {
                 if (uiStore.account) {
-                    if (tournamentStore.currentTournamentId == null) {
+                    if (!tournamentStore.currentTournamentId) {
                         this.$router.push("tournaments")
                     } else {
                         //Just for the fight counter, but it's overkill

--- a/client/src/components/import/import-table.component.vue
+++ b/client/src/components/import/import-table.component.vue
@@ -287,7 +287,7 @@ export default {
             })
         },
         async importBoxers(verifyOnly: boolean) {
-            if (this.tournamentStore.currentTournamentId === null) {
+            if (!this.tournamentStore.currentTournamentId) {
                 this.importMessage = "Please select a tournament first."
                 return
             }

--- a/client/src/components/selector/add/boxer-add-form.component.vue
+++ b/client/src/components/selector/add/boxer-add-form.component.vue
@@ -217,6 +217,7 @@ import IconComponent from "@/components/shared/core/icon.component.vue"
 import { Gender } from "@/shared/types/modality.type"
 import { ApiBoxerCreate } from "@/shared/types/api"
 import apiManager from "@/managers/api.manager"
+import { useTournamentStore } from "@/stores/tournament.store"
 
 configure({
     validateOnInput: true,
@@ -295,6 +296,7 @@ export default defineComponent({
     data() {
         return {
             onSubmit: (() => {}) as (e: Event) => void,
+            tournamentStore: useTournamentStore(),
         }
     },
     watch: {
@@ -325,6 +327,7 @@ export default defineComponent({
                 weight: parseInt(form.weight),
                 license: form.license,
                 nbFights: 0,
+                tournamentId: this.tournamentStore.currentTournamentId,
             }
             if (this.boxer?.id) {
                 await apiManager.updateBoxer(boxer, this.boxer.id)

--- a/client/src/components/selector/add/boxer-edit-offcanvas.component.vue
+++ b/client/src/components/selector/add/boxer-edit-offcanvas.component.vue
@@ -53,7 +53,6 @@ export default defineComponent({
     },
     watch: {
         "boxerStore.boxerToEdit": function (newBoxer: Boxer | null) {
-            console.log("Boxer to edit changed", newBoxer)
             if (!newBoxer) {
                 closeModal("#boxerEditOffcanvasNavbar")
             } else {
@@ -61,9 +60,18 @@ export default defineComponent({
             }
         },
     },
+    mounted() {
+        const offcanvasRef = this.$refs.offcanvas as HTMLElement
+        offcanvasRef.addEventListener("hidden.bs.offcanvas", () => {
+            this.clear()
+        })
+    },
     methods: {
         onBoxerSaved() {
             this.$emit("boxer-saved", this.boxerStore.boxerToEdit)
+            this.clear()
+        },
+        clear() {
             this.boxerStore.boxerToEdit = null
         },
     },

--- a/client/src/components/selector/add/boxer-edit-offcanvas.component.vue
+++ b/client/src/components/selector/add/boxer-edit-offcanvas.component.vue
@@ -23,7 +23,8 @@
         </div>
         <div class="offcanvas-body">
             <BoxerAddFormComponent
-                :boxer="boxer"
+                v-if="boxerStore.boxerToEdit"
+                :boxer="boxerStore.boxerToEdit"
                 @boxer-saved="onBoxerSaved()"
             ></BoxerAddFormComponent>
         </div>
@@ -31,33 +32,39 @@
 </template>
 
 <script lang="ts">
-import { PropType, defineComponent } from "vue"
-import { Boxer } from "@/types/boxing.d"
+import { defineComponent } from "vue"
 
 import BoxerAddFormComponent from "./boxer-add-form.component.vue"
-import { closeModal } from "@/utils/ui.utils"
+import { closeModal, openModal } from "@/utils/ui.utils"
 import { useUiStore } from "@/stores/ui.store"
+import { useBoxerStore } from "@/stores/boxer.store"
+import { Boxer } from "@/types/boxing"
 
 export default defineComponent({
     components: {
         BoxerAddFormComponent,
     },
-    props: {
-        boxer: {
-            type: Object as PropType<Boxer>,
-            required: true,
-        },
-    },
     emits: ["boxer-saved"],
     data() {
         return {
             uiStore: useUiStore(),
+            boxerStore: useBoxerStore(),
         }
+    },
+    watch: {
+        "boxerStore.boxerToEdit": function (newBoxer: Boxer | null) {
+            console.log("Boxer to edit changed", newBoxer)
+            if (!newBoxer) {
+                closeModal("#boxerEditOffcanvasNavbar")
+            } else {
+                openModal("#boxerEditOffcanvasNavbar")
+            }
+        },
     },
     methods: {
         onBoxerSaved() {
-            closeModal("#boxerEditOffcanvasNavbar")
-            this.$emit("boxer-saved", this.boxer)
+            this.$emit("boxer-saved", this.boxerStore.boxerToEdit)
+            this.boxerStore.boxerToEdit = null
         },
     },
 })

--- a/client/src/components/selector/boxer-details.component.vue
+++ b/client/src/components/selector/boxer-details.component.vue
@@ -67,14 +67,12 @@
                             class="btn btn-sm btn-outline-success"
                             data-bs-toggle="offcanvas"
                             data-bs-target="#boxerEditOffcanvasNavbar"
+                            @click="editBoxer()"
                         >
                             <i class="bi bi-pencil"></i>
                             Edit boxer
                         </div>
-                        <BoxerEditOffcanvasComponent
-                            :boxer="boxer"
-                            @boxer-saved="fetchBoxerData()"
-                        />
+                        <BoxerEditOffcanvasComponent @boxer-saved="fetchBoxerData()" />
                     </div>
                 </div>
             </div>
@@ -189,6 +187,12 @@ export default defineComponent({
             }
             const text = getClipboardText(this.boxer)
             navigator.clipboard.writeText(text)
+        },
+        editBoxer() {
+            if (!this.boxer) {
+                return
+            }
+            this.boxerStore.boxerToEdit = this.boxer
         },
     },
 })

--- a/client/src/components/selector/boxer-selector.component.vue
+++ b/client/src/components/selector/boxer-selector.component.vue
@@ -74,6 +74,7 @@
             </button>
             <BoxerSelectorFiltersComponent />
             <BoxerAddOffcanvasComponent @boxer-saved="onBoxerSaved" />
+            <BoxerEditOffcanvasComponent @boxer-saved="onBoxerSaved" />
         </div>
         <div class="mb-2 row">
             <!-- Search bar -->
@@ -131,6 +132,7 @@ import { defineComponent, watch } from "vue"
 import { Gender, ModalityErrorType } from "@/shared/types/modality.type"
 import BoxerTileComponent from "@/components/selector/boxer-tile.component.vue"
 import BoxerAddOffcanvasComponent from "@/components/selector/add/boxer-add-offcanvas.component.vue"
+import BoxerEditOffcanvasComponent from "@/components/selector/add/boxer-edit-offcanvas.component.vue"
 
 import BoxerSelectorFiltersComponent from "@/components/selector/boxer-selector-filters.component.vue"
 import { useTournamentStore } from "@/stores/tournament.store"
@@ -152,6 +154,7 @@ export default defineComponent({
         BoxerSelectorFiltersComponent: BoxerSelectorFiltersComponent,
         SearchFacetsComponent: SearchFacetsComponent,
         TournamentHeaderComponent: TournamentHeaderComponent,
+        BoxerEditOffcanvasComponent: BoxerEditOffcanvasComponent,
     },
     data() {
         return {
@@ -166,6 +169,7 @@ export default defineComponent({
             searchQuery: "", // Added for search bar binding
             boxersToDisplay: [] as Boxer[],
             searchTimeout: null as number | null,
+            boxerToEdit: null as Boxer | null,
         }
     },
     computed: {

--- a/client/src/components/selector/boxer-tile.component.vue
+++ b/client/src/components/selector/boxer-tile.component.vue
@@ -44,8 +44,8 @@
                     class="btn btn-outline-success btn-sm"
                     @click="editBoxer()"
                 >
-                    <i class="bi bi-clipboard" />
-                    <span class="d-none d-sm-inline ms-2">Edit boxer</span>
+                    <i class="bi bi-pencil" />
+                    <span class="ms-2">Edit</span>
                 </button>
                 <button
                     class="btn btn-outline-secondary btn-sm"

--- a/client/src/components/selector/boxer-tile.component.vue
+++ b/client/src/components/selector/boxer-tile.component.vue
@@ -41,6 +41,13 @@
                     <span class="ms-1">Select opponents</span>
                 </button>
                 <button
+                    class="btn btn-outline-success btn-sm"
+                    @click="editBoxer()"
+                >
+                    <i class="bi bi-clipboard" />
+                    <span class="d-none d-sm-inline ms-2">Edit boxer</span>
+                </button>
+                <button
                     class="btn btn-outline-secondary btn-sm"
                     @click="copyToClipboard()"
                 >
@@ -107,6 +114,12 @@ export default defineComponent({
         copyToClipboard() {
             const text = getClipboardText(this.boxer)
             navigator.clipboard.writeText(text)
+        },
+        editBoxer() {
+            if (!this.boxer) {
+                return
+            }
+            this.boxerStore.boxerToEdit = this.boxer
         },
     },
 })

--- a/client/src/components/shared/layout/menu-top.component.vue
+++ b/client/src/components/shared/layout/menu-top.component.vue
@@ -95,7 +95,7 @@ export default {
             return this.fightStore.fights.length
         },
         isTournamentSelected(): boolean {
-            return this.tournamentStore.currentTournamentId != null
+            return !this.tournamentStore.currentTournamentId
         },
     },
     methods: {

--- a/client/src/components/shared/layout/menu-top.component.vue
+++ b/client/src/components/shared/layout/menu-top.component.vue
@@ -95,7 +95,7 @@ export default {
             return this.fightStore.fights.length
         },
         isTournamentSelected(): boolean {
-            return !this.tournamentStore.currentTournamentId
+            return !!this.tournamentStore.currentTournamentId
         },
     },
     methods: {

--- a/client/src/stores/boxer.store.ts
+++ b/client/src/stores/boxer.store.ts
@@ -51,40 +51,5 @@ export const useBoxerStore = defineStore("boxer", {
                 this.loading = false
             }
         },
-        async createBoxer(boxer: Boxer): Promise<Boxer> {
-            try {
-                const tournamentStore = useTournamentStore()
-                const apiBoxerCreate = ApiAdapter.toApiBoxerCreate(
-                    boxer,
-                    tournamentStore.currentTournamentId || undefined
-                )
-                const created: ApiBoxerGet = await dbManager.addBoxer(apiBoxerCreate)
-                const newBoxer = ApiAdapter.toBoxer(created)
-                this.boxers.push(newBoxer)
-                return newBoxer
-            } catch (e: unknown) {
-                this.error = e instanceof Error ? e.message : "Unknown error"
-                throw e
-            }
-        },
-        async updateBoxer(boxer: Boxer): Promise<Boxer> {
-            try {
-                const apiBoxerUpdate = ApiAdapter.toApiBoxerCreate(boxer, undefined)
-                const updated: ApiBoxerGet = await dbManager.updateBoxer(apiBoxerUpdate, boxer.id)
-                const updatedBoxer = ApiAdapter.toBoxer(updated)
-                // Update the boxer in the store
-                const idx = this.boxers.findIndex((b) => b.id === updatedBoxer.id)
-                if (idx !== -1) {
-                    this.boxers[idx] = updatedBoxer
-                }
-                return updatedBoxer
-            } catch (e: unknown) {
-                this.error = e instanceof Error ? e.message : "Unknown error"
-                throw e
-            }
-        },
-        getBoxerById(boxerId: string): Boxer | undefined {
-            return this.boxers.find((b) => b.id === boxerId)
-        },
     },
 })

--- a/client/src/stores/boxer.store.ts
+++ b/client/src/stores/boxer.store.ts
@@ -11,6 +11,7 @@ export const useBoxerStore = defineStore("boxer", {
         loading: false,
         error: null as string | null,
         restored: false,
+        boxerToEdit: null as Boxer | null,
     }),
     actions: {
         async fetchBoxers() {

--- a/client/src/stores/tournament.store.ts
+++ b/client/src/stores/tournament.store.ts
@@ -9,7 +9,7 @@ export const useTournamentStore = defineStore("tournament", {
         tournaments: [] as Tournament[],
         loading: false,
         error: null as string | null,
-        currentTournamentId: null as string | null,
+        currentTournamentId: undefined as string | undefined,
     }),
     actions: {
         async fetchTournaments() {
@@ -24,12 +24,12 @@ export const useTournamentStore = defineStore("tournament", {
                 this.loading = false
             }
         },
-        setCurrentTournament(tournamentId: string | null) {
+        setCurrentTournament(tournamentId?: string) {
             this.currentTournamentId = tournamentId
         },
-        getCurrentTournament(): Tournament | null {
+        getCurrentTournament(): Tournament | undefined {
             const tournament = this.tournaments.find((t) => t.id === this.currentTournamentId)
-            return tournament || null
+            return tournament
         },
     },
 })

--- a/client/src/utils/ui.utils.ts
+++ b/client/src/utils/ui.utils.ts
@@ -6,3 +6,9 @@ export function closeModal(instanceName: string) {
         bsOffcanvas.hide()
     }
 }
+export function openModal(instanceName: string) {
+    const bsOffcanvas = bootstrap.getInstance().Offcanvas.getOrCreateInstance(instanceName)
+    if (bsOffcanvas) {
+        bsOffcanvas.show()
+    }
+}


### PR DESCRIPTION
This pull request refactors the boxer editing workflow and improves tournament selection handling across the application. The main changes include introducing a centralized boxer editing flow using a shared store property, updating the boxer form to use API calls directly, and standardizing tournament ID handling to use `undefined` instead of `null`. Several components have been updated to reflect these changes, simplifying state management and improving code consistency.

**Boxer Editing Workflow Refactor:**

* Added a `boxerToEdit` property to the `boxerStore` and refactored editing logic so components now use this shared property to manage the boxer being edited, removing the need to pass boxer objects via props. The edit offcanvas is now opened/closed based on this property, and the boxer form watches changes to it. (`client/src/stores/boxer.store.ts` [[1]](diffhunk://#diff-90d30065edb5d43f87739f91b6048858d0c909c4b2e69809b7b0134ece34aa8cR14) `client/src/components/selector/add/boxer-edit-offcanvas.component.vue` [[2]](diffhunk://#diff-43fb6f344577b65485a00e6bae1a1141001b82b1aec5dc497b59c49378b47bcbL26-R75) `client/src/components/selector/boxer-details.component.vue` [[3]](diffhunk://#diff-d973629eee28b7f0ee871b4fb7cf56d8f5f6137830a134b193ed221138030f5aR70-R75) [[4]](diffhunk://#diff-d973629eee28b7f0ee871b4fb7cf56d8f5f6137830a134b193ed221138030f5aR191-R196) `client/src/components/selector/boxer-tile.component.vue` [[5]](diffhunk://#diff-3f6de758ee44c01ffb3cfa64566e251d1963f0b96e1db448daeb4f7ac4f6dba0R43-R49) [[6]](diffhunk://#diff-3f6de758ee44c01ffb3cfa64566e251d1963f0b96e1db448daeb4f7ac4f6dba0R118-R123) `client/src/components/selector/boxer-selector.component.vue` [[7]](diffhunk://#diff-e5da599ba999624e591bfce335c1bba4172c457e18c5529f7681692f39a38e24R77) [[8]](diffhunk://#diff-e5da599ba999624e591bfce335c1bba4172c457e18c5529f7681692f39a38e24R135) [[9]](diffhunk://#diff-e5da599ba999624e591bfce335c1bba4172c457e18c5529f7681692f39a38e24R157) [[10]](diffhunk://#diff-e5da599ba999624e591bfce335c1bba4172c457e18c5529f7681692f39a38e24R172)

* Boxer form (`boxer-add-form.component.vue`) now directly calls API manager methods for add/update actions, removing dependency on boxer store actions and simplifying the form logic. Error toast logic has been removed. (`client/src/components/selector/add/boxer-add-form.component.vue` [[1]](diffhunk://#diff-9216e6bd11a62f2dfedb30a11a8348c64500a732b14e73f4bec4c8d356a9a4f7L2-L22) [[2]](diffhunk://#diff-9216e6bd11a62f2dfedb30a11a8348c64500a732b14e73f4bec4c8d356a9a4f7L238-R220) [[3]](diffhunk://#diff-9216e6bd11a62f2dfedb30a11a8348c64500a732b14e73f4bec4c8d356a9a4f7L280-R261) [[4]](diffhunk://#diff-9216e6bd11a62f2dfedb30a11a8348c64500a732b14e73f4bec4c8d356a9a4f7L303) [[5]](diffhunk://#diff-9216e6bd11a62f2dfedb30a11a8348c64500a732b14e73f4bec4c8d356a9a4f7L314-R339)

**Tournament Selection Handling:**

* Standardized tournament ID handling to use `undefined` instead of `null` throughout the tournament store and relevant components, improving type safety and consistency. (`client/src/stores/tournament.store.ts` [[1]](diffhunk://#diff-96459d66a849cb2521d2cdf68fbfc112a695f8e927dc519344efe5283ee6a1fbL12-R12) [[2]](diffhunk://#diff-96459d66a849cb2521d2cdf68fbfc112a695f8e927dc519344efe5283ee6a1fbL27-R32) `client/src/components/shared/layout/menu-top.component.vue` [[3]](diffhunk://#diff-6860e41027af3ef9f05fc4a090b4c132c0c00ce6cc4f300862f0b68f3904fe18L98-R98) `client/src/app.vue` [[4]](diffhunk://#diff-116db95433505d988f7dfbc1dc55240e82ddd4fe9c4a78de035d50e4ec3b2bdcL45-R45) `client/src/components/import/import-table.component.vue` [[5]](diffhunk://#diff-62855399b262d9e1bd5bf35cd1bc13c8616eb69c00ed641b20eccc6b51ebcf55L290-R290)

**Utility Function Improvements:**

* Added a new `openModal` utility function to complement the existing `closeModal`, allowing components to programmatically show offcanvas modals. (`client/src/utils/ui.utils.ts` [client/src/utils/ui.utils.tsR9-R14](diffhunk://#diff-376c8cea8f42d2dcf3cfa94fd7126ffd964667aff6355fd608153aca09036452R9-R14))

**Cleanup and Removal of Unused Code:**

* Removed unused boxer store actions (`createBoxer`, `updateBoxer`, `getBoxerById`) as API interactions are now handled directly in the form component. (`client/src/stores/boxer.store.ts` [client/src/stores/boxer.store.tsL53-L87](diffhunk://#diff-90d30065edb5d43f87739f91b6048858d0c909c4b2e69809b7b0134ece34aa8cL53-L87))

These changes collectively streamline the boxer editing experience, improve code maintainability, and ensure more consistent handling of tournament selection across the app.