### PR TITLE
Add additional information fields to tournament and update related co…

### DIFF
--- a/client/src/adapters/api.adapter.ts
+++ b/client/src/adapters/api.adapter.ts
@@ -66,6 +66,7 @@ export default class ApiAdapter {
             zipCode: tournament.zipCode,
             city: tournament.city,
             formattedAddress: tournament.formattedAddress,
+            additionalInfo: tournament.additionalInfo,
         }
     }
 
@@ -75,9 +76,10 @@ export default class ApiAdapter {
             name: tournament.name,
             userId: tournament.userId,
             date: tournament.date,
-            address: tournament.address,
-            zipCode: tournament.zipCode,
-            city: tournament.city,
+            address: tournament.address || "",
+            zipCode: tournament.zipCode || "",
+            city: tournament.city || "",
+            additionalInfo: tournament.additionalInfo,
         }
     }
 
@@ -85,9 +87,10 @@ export default class ApiAdapter {
         return {
             name: tournament.name,
             date: tournament.date,
-            address: tournament.address,
-            zipCode: tournament.zipCode,
-            city: tournament.city,
+            address: tournament.address || "",
+            zipCode: tournament.zipCode || "",
+            city: tournament.city || "",
+            additionalInfo: tournament.additionalInfo,
         }
     }
 
@@ -109,6 +112,10 @@ export default class ApiAdapter {
             tournamentName: sharedFightCardApi.tournamentName,
             fights: sharedFightCardApi.fights.map(ApiAdapter.toFight),
             tournamentDate: sharedFightCardApi.tournamentDate,
+            additionalInfo: sharedFightCardApi.additionalInfo,
+            address: sharedFightCardApi.address,
+            zipCode: sharedFightCardApi.zipCode,
+            city: sharedFightCardApi.city,
         }
     }
 }

--- a/client/src/components/fight-card/shared-fight-card.component.vue
+++ b/client/src/components/fight-card/shared-fight-card.component.vue
@@ -1,6 +1,6 @@
 <template>
     <template v-if="tournament">
-        <div class="d-flex mb-3 justify-content-between align-items-center">
+        <div class="d-flex mb-2 justify-content-between align-items-center">
             <router-link
                 :to="{ path: '/' }"
                 class="d-flex align-items-center text-decoration-none"
@@ -20,9 +20,25 @@
                 {{ $t("sharedFightCard.download") }}
             </button>
         </div>
-        <div class="d-flex mb-3 justify-content-between align-items-center">
-            <h5>{{ tournament?.tournamentName }}</h5>
+        <div class="d-flex mb-1 justify-content-between align-items-baseline">
+            <h5>{{ tournament.tournamentName }}</h5>
             {{ tournamentDate }}
+        </div>
+        <div
+            v-if="fullAddress"
+            class="mb-3"
+        >
+            <i class="bi bi-geo-alt-fill me-2"></i>
+            <a
+                :href="`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(fullAddress)}`"
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                {{ fullAddress }}
+            </a>
+        </div>
+        <div class="mb-3 fst-italic text-muted">
+            {{ tournament.additionalInfo }}
         </div>
         <div class="border border-light-subtle rounded-3 p-1">
             <FightCardGridComponent
@@ -91,6 +107,7 @@ import ApiAdapter from "@/adapters/api.adapter"
 import ShareComponent from "@/components/shared/core/share.component.vue"
 import IconComponent from "@/components/shared/core/icon.component.vue"
 import { downloadWithDom } from "@/utils/download.utils"
+import { getFullAddress } from "@/utils/string.utils"
 
 const { t: $t, locale } = useI18n()
 
@@ -100,6 +117,13 @@ const showShareOffcanvas = ref(false)
 const roToken = ref<string | null>(null)
 const tournament = ref<SharedFightCard | null>(null)
 const accessDenied = ref(false)
+
+const fullAddress = computed(() => {
+    if (!tournament.value) {
+        return ""
+    }
+    return getFullAddress(tournament.value.address, tournament.value.zipCode, tournament.value.city)
+})
 
 const tournamentDate = computed(() => {
     return tournament.value?.tournamentDate

--- a/client/src/components/tournament/tournament-add-offcanvas.component.vue
+++ b/client/src/components/tournament/tournament-add-offcanvas.component.vue
@@ -36,6 +36,22 @@
             </div>
             <div class="mb-3">
                 <label
+                    for="additionalInfo"
+                    class="form-label"
+                >
+                    <i class="bi bi-info-circle me-2"></i>{{ $t("tournamentAdd.additionalInfo") }}
+                </label>
+                <textarea
+                    v-model="additionalInfo"
+                    class="form-control"
+                    rows="3"
+                ></textarea>
+                <div class="form-text text-muted">
+                    {{ $t("tournamentAdd.additionalInfoExportNotice") }}
+                </div>
+            </div>
+            <div class="mb-3">
+                <label
                     for="date"
                     class="form-label"
                 >
@@ -167,7 +183,7 @@ const [date] = defineField("date")
 const [address] = defineField("address")
 const [zipCode] = defineField("zipCode")
 const [city] = defineField("city")
-
+const [additionalInfo] = defineField("additionalInfo")
 const mode = computed<"create" | "edit">(() => (props.tournament ? "edit" : "create"))
 
 // Sync prop into fields
@@ -180,6 +196,7 @@ watch(
         address.value = t?.address || ""
         zipCode.value = t?.zipCode || ""
         city.value = t?.city || ""
+        additionalInfo.value = t?.additionalInfo || ""
     },
     { immediate: true }
 )
@@ -188,9 +205,10 @@ const onSubmit = handleSubmit(async (form: GenericObject) => {
     const formTournament = {
         name: form.name,
         date: form.date,
-        address: form.address || undefined,
-        zipCode: form.zipCode || undefined,
-        city: form.city || undefined,
+        address: form.address || "",
+        zipCode: form.zipCode || "",
+        city: form.city || "",
+        additionalInfo: form.additionalInfo || "",
     }
     let tournamentId = ""
     if (props.tournament) {

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -258,8 +258,7 @@
     "updateEvent": "Update event",
     "validation": {
       "required": "This field is required"
-    },
-    "additionalInfo": "Additional infos"
+    }
   },
   "tournaments": {
     "addTournament": "Add tournament",

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -244,6 +244,8 @@
     "checkLink": "Please check the link or contact the owner of the fight card."
   },
   "tournamentAdd": {
+    "additionalInfo": "Additional information",
+    "additionalInfoExportNotice": "This information will be displayed in the exported fight card.",
     "addEvent": "Add new event",
     "editEvent": "Edit event",
     "name": "Name",
@@ -256,7 +258,8 @@
     "updateEvent": "Update event",
     "validation": {
       "required": "This field is required"
-    }
+    },
+    "additionalInfo": "Additional infos"
   },
   "tournaments": {
     "addTournament": "Add tournament",

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -244,6 +244,7 @@
         "checkLink": "Veuillez vérifier le lien ou contacter le propriétaire de la carte de combat."
     },
     "tournamentAdd": {
+        "additionalInfoExportNotice": "Cette information sera affichée sur la carte de combat exportée.",
         "addEvent": "Ajouter un nouvel événement",
         "editEvent": "Modifier l'événement",
         "name": "Nom",
@@ -256,7 +257,8 @@
         "updateEvent": "Mettre à jour l'événement",
         "validation": {
             "required": "Ce champ est requis"
-        }
+        },
+        "additionalInfo": "Informations importantes"
     },
     "tournaments": {
         "addTournament": "Ajouter un tournoi",

--- a/client/src/types/boxing.d.ts
+++ b/client/src/types/boxing.d.ts
@@ -77,12 +77,17 @@ export interface Tournament {
     zipCode?: string
     city?: string
     formattedAddress?: string
+    additionalInfo: string
 }
 
 export interface SharedFightCard {
     tournamentName: string
     fights: Fight[]
     tournamentDate?: string
+    additionalInfo: string
+    address?: string
+    zipCode?: string
+    city?: string
 }
 
 export interface DownloadOptions {

--- a/client/src/utils/string.utils.ts
+++ b/client/src/utils/string.utils.ts
@@ -24,3 +24,16 @@ export function getAgeDifference(date1: Date, date2: Date): string {
     const duration = intervalToDuration({ start, end })
     return formatDuration(duration, { format: ["years", "months", "days"] })
 }
+
+export function getFullAddress(
+    address: string | undefined,
+    zipCode: string | undefined,
+    city: string | undefined
+): string {
+    // Build a pretty address string, skipping empty parts and using proper separators
+    const parts = []
+    if (address) parts.push(address.trim())
+    if (zipCode) parts.push(zipCode.trim())
+    if (city) parts.push(city.trim())
+    return parts.filter(Boolean).join(", ")
+}

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1503,15 +1503,15 @@
           },
           "address": {
             "type": "string",
-            "description": "Tournament address (optional)"
+            "description": "Tournament address"
           },
           "zipCode": {
             "type": "string",
-            "description": "Tournament zip code (optional)"
+            "description": "Tournament zip code"
           },
           "city": {
             "type": "string",
-            "description": "Tournament city (optional)"
+            "description": "Tournament city"
           },
           "formattedAddress": {
             "type": "string",
@@ -1519,7 +1519,7 @@
           },
           "additionalInfo": {
             "type": "string",
-            "description": "Additional info (optional)"
+            "description": "Additional info"
           }
         },
         "required": [
@@ -1546,19 +1546,19 @@
           },
           "address": {
             "type": "string",
-            "description": "Tournament address (optional)"
+            "description": "Tournament address"
           },
           "zipCode": {
             "type": "string",
-            "description": "Tournament zip code (optional)"
+            "description": "Tournament zip code"
           },
           "city": {
             "type": "string",
-            "description": "Tournament city (optional)"
+            "description": "Tournament city"
           },
           "additionalInfo": {
             "type": "string",
-            "description": "Additional info (optional)"
+            "description": "Additional info"
           }
         },
         "required": [
@@ -1583,19 +1583,19 @@
           },
           "address": {
             "type": "string",
-            "description": "Tournament address (optional)"
+            "description": "Tournament address"
           },
           "zipCode": {
             "type": "string",
-            "description": "Tournament zip code (optional)"
+            "description": "Tournament zip code"
           },
           "city": {
             "type": "string",
-            "description": "Tournament city (optional)"
+            "description": "Tournament city"
           },
           "additionalInfo": {
             "type": "string",
-            "description": "Additional info (optional)"
+            "description": "Additional info"
           }
         },
         "required": [
@@ -2387,11 +2387,11 @@
           },
           "tournamentDate": {
             "type": "string",
-            "description": "Tournament date (optional)"
+            "description": "Tournament date"
           },
           "additionalInfo": {
             "type": "string",
-            "description": "Additional info (optional)"
+            "description": "Additional info"
           },
           "address": {
             "type": "string"

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1516,13 +1516,21 @@
           "formattedAddress": {
             "type": "string",
             "description": "Formatted address combining street, city, and zipCode"
+          },
+          "additionalInfo": {
+            "type": "string",
+            "description": "Additional info (optional)"
           }
         },
         "required": [
           "id",
           "name",
           "userId",
-          "date"
+          "date",
+          "address",
+          "zipCode",
+          "city",
+          "additionalInfo"
         ]
       },
       "CreateTournamentDto": {
@@ -1547,11 +1555,19 @@
           "city": {
             "type": "string",
             "description": "Tournament city (optional)"
+          },
+          "additionalInfo": {
+            "type": "string",
+            "description": "Additional info (optional)"
           }
         },
         "required": [
           "name",
-          "date"
+          "date",
+          "address",
+          "zipCode",
+          "city",
+          "additionalInfo"
         ]
       },
       "UpdateTournamentDto": {
@@ -1576,11 +1592,19 @@
           "city": {
             "type": "string",
             "description": "Tournament city (optional)"
+          },
+          "additionalInfo": {
+            "type": "string",
+            "description": "Additional info (optional)"
           }
         },
         "required": [
           "name",
-          "date"
+          "date",
+          "address",
+          "zipCode",
+          "city",
+          "additionalInfo"
         ]
       },
       "Gender": {
@@ -2364,11 +2388,28 @@
           "tournamentDate": {
             "type": "string",
             "description": "Tournament date (optional)"
+          },
+          "additionalInfo": {
+            "type": "string",
+            "description": "Additional info (optional)"
+          },
+          "address": {
+            "type": "string"
+          },
+          "zipCode": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
           }
         },
         "required": [
           "tournamentName",
-          "fights"
+          "fights",
+          "additionalInfo",
+          "address",
+          "zipCode",
+          "city"
         ]
       },
       "GenerateFightCardTokenDto": {

--- a/server/src/adapters/fight.adapter.ts
+++ b/server/src/adapters/fight.adapter.ts
@@ -41,6 +41,7 @@ export function toFightCardTemplate(
     subtitle: format(tournament.date, 'dd/MM/yyyy'),
     title: tournament.name,
     cornerColspan: colspan,
+    additionalInfo: tournament.additionalInfo,
     formattedAddress: formatAddress({
       street: tournament.address,
       city: tournament.city,

--- a/server/src/adapters/share.adapter.ts
+++ b/server/src/adapters/share.adapter.ts
@@ -16,5 +16,9 @@ export function toSharedFightCardDto(
       ? format(new Date(tournament.date), 'dd/MM/yyyy')
       : undefined,
     fights: fights.map((fight) => toFightDto(fight, modality)),
+    additionalInfo: tournament.additionalInfo || '',
+    address: tournament.address || '',
+    zipCode: tournament.zipCode || '',
+    city: tournament.city || '',
   };
 }

--- a/server/src/adapters/tournament.adapter.ts
+++ b/server/src/adapters/tournament.adapter.ts
@@ -12,14 +12,15 @@ export function toTournamentDto(tournament: Tournament): TournamentDto {
     name: tournament.name,
     userId: tournament.userId,
     date: tournament.date,
-    address: tournament.address,
-    zipCode: tournament.zipCode,
-    city: tournament.city,
+    address: tournament.address || '',
+    zipCode: tournament.zipCode || '',
+    city: tournament.city || '',
     formattedAddress: formatAddress({
       street: tournament.address,
       city: tournament.city,
       zipCode: tournament.zipCode,
     }),
+    additionalInfo: tournament.additionalInfo || '',
   };
 }
 
@@ -35,6 +36,7 @@ export function toTournament(
   entity.address = tournament.address;
   entity.zipCode = tournament.zipCode;
   entity.city = tournament.city;
+  entity.additionalInfo = tournament.additionalInfo;
   return entity;
 }
 
@@ -49,6 +51,7 @@ export function toTournamentFromCreateDto(
   entity.address = tournament.address;
   entity.zipCode = tournament.zipCode;
   entity.city = tournament.city;
+  entity.additionalInfo = tournament.additionalInfo;
   return entity;
 }
 
@@ -63,5 +66,6 @@ export function toTournamentFromUpdateDto(
   entity.address = tournament.address;
   entity.zipCode = tournament.zipCode;
   entity.city = tournament.city;
+  entity.additionalInfo = tournament.additionalInfo;
   return entity;
 }

--- a/server/src/dto/tournament.dto.ts
+++ b/server/src/dto/tournament.dto.ts
@@ -6,6 +6,7 @@ import {
   MaxLength,
   IsArray,
   ValidateNested,
+  MinLength,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { FightDto } from './fight.dto';
@@ -23,22 +24,23 @@ export class CreateTournamentDto {
   date: string;
 
   /** Tournament address (optional) */
-  @IsOptional()
   @IsString()
   @MaxLength(200)
-  address?: string;
+  address: string;
 
   /** Tournament zip code (optional) */
-  @IsOptional()
   @IsString()
   @MaxLength(10)
-  zipCode?: string;
+  @MinLength(0)
+  zipCode: string;
 
   /** Tournament city (optional) */
-  @IsOptional()
   @IsString()
   @MaxLength(100)
-  city?: string;
+  city: string;
+  /** Additional info (optional) */
+  @IsString()
+  additionalInfo: string;
 }
 
 export class UpdateTournamentDto extends CreateTournamentDto {}
@@ -53,13 +55,15 @@ export class TournamentDto {
   /** Tournament date (YYYY-MM-DD) */
   date: string;
   /** Tournament address (optional) */
-  address?: string;
+  address: string;
   /** Tournament zip code (optional) */
-  zipCode?: string;
+  zipCode: string;
   /** Tournament city (optional) */
-  city?: string;
+  city: string;
   /** Formatted address combining street, city, and zipCode */
   formattedAddress?: string;
+  /** Additional info (optional) */
+  additionalInfo: string;
 }
 
 export class SharedFightCardDto {
@@ -77,4 +81,18 @@ export class SharedFightCardDto {
   @IsOptional()
   @IsString()
   tournamentDate?: string;
+
+  /** Additional info (optional) */
+  @IsString()
+  additionalInfo: string;
+
+  @IsString()
+  @IsOptional()
+  address: string;
+  @IsString()
+  @IsOptional()
+  zipCode: string;
+  @IsString()
+  @IsOptional()
+  city: string;
 }

--- a/server/src/dto/tournament.dto.ts
+++ b/server/src/dto/tournament.dto.ts
@@ -23,22 +23,22 @@ export class CreateTournamentDto {
   @IsNotEmpty()
   date: string;
 
-  /** Tournament address (optional) */
+  /** Tournament address */
   @IsString()
   @MaxLength(200)
   address: string;
 
-  /** Tournament zip code (optional) */
+  /** Tournament zip code */
   @IsString()
   @MaxLength(10)
   @MinLength(0)
   zipCode: string;
 
-  /** Tournament city (optional) */
+  /** Tournament city */
   @IsString()
   @MaxLength(100)
   city: string;
-  /** Additional info (optional) */
+  /** Additional info */
   @IsString()
   additionalInfo: string;
 }
@@ -54,15 +54,15 @@ export class TournamentDto {
   userId: string;
   /** Tournament date (YYYY-MM-DD) */
   date: string;
-  /** Tournament address (optional) */
+  /** Tournament address */
   address: string;
-  /** Tournament zip code (optional) */
+  /** Tournament zip code */
   zipCode: string;
-  /** Tournament city (optional) */
+  /** Tournament city */
   city: string;
   /** Formatted address combining street, city, and zipCode */
   formattedAddress?: string;
-  /** Additional info (optional) */
+  /** Additional info */
   additionalInfo: string;
 }
 
@@ -77,12 +77,12 @@ export class SharedFightCardDto {
   @Type(() => FightDto)
   fights: FightDto[];
 
-  /** Tournament date (optional) */
+  /** Tournament date*/
   @IsOptional()
   @IsString()
   tournamentDate?: string;
 
-  /** Additional info (optional) */
+  /** Additional info */
   @IsString()
   additionalInfo: string;
 

--- a/server/src/entities/tournament.entity.ts
+++ b/server/src/entities/tournament.entity.ts
@@ -33,4 +33,6 @@ export class Tournament {
 
   @Column({ nullable: true })
   city?: string;
+  @Column({ type: 'text', nullable: true })
+  additionalInfo?: string;
 }

--- a/server/src/interfaces/template.interface.ts
+++ b/server/src/interfaces/template.interface.ts
@@ -20,6 +20,7 @@ export interface FightCardTemplate {
   formattedAddress?: string;
   downloadOptions: DownloadOptionsDto;
   cornerColspan: number;
+  additionalInfo?: string;
 }
 
 export interface FightCardI18nTemplate {

--- a/server/src/services/tournament.service.ts
+++ b/server/src/services/tournament.service.ts
@@ -208,6 +208,7 @@ export class TournamentService {
       address: 'Gymnase Louis Volcair',
       zipCode: '35200',
       city: 'Rennes',
+      additionalInfo: 'Weight-in at 6 PM.',
     };
     const dbTournament = await this.tournamentRepository.save(
       toTournamentFromCreateDto(fakeTournament, user.id),

--- a/server/src/utils/addressUtils.ts
+++ b/server/src/utils/addressUtils.ts
@@ -3,7 +3,7 @@ export function formatAddress(properties?: {
   city?: string;
   zipCode?: string;
 }): string {
-  return [properties?.street, properties?.city, properties?.zipCode]
+  return [properties?.street, properties?.zipCode, properties?.city]
     .filter(Boolean)
     .join(', ');
 }

--- a/server/src/views/fight-card.mustache
+++ b/server/src/views/fight-card.mustache
@@ -46,8 +46,9 @@
     <div class="header d-flex">
       <div class="qr-code"></div>
       <div class="d-flex flex-column m-auto align-items-center">
-        <span class="fs-2">{{title}}</span>
+        <span class="fs-3">{{title}}</span>
         <span class="fs-5">{{subtitle}} - {{formattedAddress}}</span>
+        <span class="fs-6 fst-italic">{{additionalInfo}}</span>
       </div>
       <div class="qr-code">
         {{{qrCodeSvg}}}
@@ -58,7 +59,10 @@
     {{^qrCodeSvg}}
     <div class="header d-flex justify-content-between align-items-center">
       <span class="fs-2">{{title}}</span>
-      <span class="fs-5">{{subtitle}} - {{formattedAddress}}</span>
+      <div>
+        <div class="fs-5">{{subtitle}} - {{formattedAddress}}</div>
+        <div class="fs-6 fst-italic text-end">{{additionalInfo}}</div>
+      </div>
     </div>
     {{/qrCodeSvg}}
     {{/downloadOptions.displayTitle}}


### PR DESCRIPTION
This pull request introduces support for an "additional information" field for tournaments, ensuring it is captured, stored, and displayed throughout the application. It also improves how tournament addresses are handled and displayed, and updates the API and validation logic to treat address-related fields as required (but allow empty strings). The user interface is enhanced to allow entry and display of the additional info, including in the exported/shared fight card view. Localization files are updated to support the new field.

**Tournament additional information support:**

* Added `additionalInfo` field to tournament-related DTOs, database entity, and OpenAPI schema, ensuring it is handled in create, update, and read flows (`server/src/dto/tournament.dto.ts`, `server/src/entities/tournament.entity.ts`, `server/openapi.json`, `server/src/adapters/tournament.adapter.ts`, `server/src/adapters/fight.adapter.ts`, `server/src/adapters/share.adapter.ts`) [[1]](diffhunk://#diff-017eab98f7afb91a8d32e3ec52566d6386a3991f735c6ee57e2c382b035eb151L26-R43) [[2]](diffhunk://#diff-017eab98f7afb91a8d32e3ec52566d6386a3991f735c6ee57e2c382b035eb151L56-R66) [[3]](diffhunk://#diff-017eab98f7afb91a8d32e3ec52566d6386a3991f735c6ee57e2c382b035eb151R84-R97) [[4]](diffhunk://#diff-4e5d75d55c0a790dcddb7e261b2cd3359892409739cdbb7a119d68bf3d469571R36-R37) [[5]](diffhunk://#diff-7fb07de1be049a080f522474879c7e1392b8132cc0f56a49e654f9e2cafbde45R1519-R1533) [[6]](diffhunk://#diff-7fb07de1be049a080f522474879c7e1392b8132cc0f56a49e654f9e2cafbde45R1558-R1570) [[7]](diffhunk://#diff-7fb07de1be049a080f522474879c7e1392b8132cc0f56a49e654f9e2cafbde45R1595-R1607) [[8]](diffhunk://#diff-7fb07de1be049a080f522474879c7e1392b8132cc0f56a49e654f9e2cafbde45R2391-R2412) [[9]](diffhunk://#diff-109adbffbe5d207ce9f5861c96bde3f77619ee21e1ef4251a2fc5bdb87be7835L15-R23) [[10]](diffhunk://#diff-109adbffbe5d207ce9f5861c96bde3f77619ee21e1ef4251a2fc5bdb87be7835R39) [[11]](diffhunk://#diff-109adbffbe5d207ce9f5861c96bde3f77619ee21e1ef4251a2fc5bdb87be7835R54) [[12]](diffhunk://#diff-109adbffbe5d207ce9f5861c96bde3f77619ee21e1ef4251a2fc5bdb87be7835R69) [[13]](diffhunk://#diff-4e2f93e9d159a5d24696529630638fa573a1256a7b74821c51b6f32fa1f8bd68R44) [[14]](diffhunk://#diff-030df6a289db338a05d451e365df95bccbe05d9d4d2f908ced627506417371bdR19-R22).

* Updated the frontend to support entry and display of `additionalInfo` in the tournament add/edit form and the shared fight card view (`client/src/components/tournament/tournament-add-offcanvas.component.vue`, `client/src/components/fight-card/shared-fight-card.component.vue`) [[1]](diffhunk://#diff-f46303604524248590a05ace7999fc60bac290d68e7430ae9da4a38f7784d191R37-R52) [[2]](diffhunk://#diff-f46303604524248590a05ace7999fc60bac290d68e7430ae9da4a38f7784d191L170-R186) [[3]](diffhunk://#diff-f46303604524248590a05ace7999fc60bac290d68e7430ae9da4a38f7784d191R199) [[4]](diffhunk://#diff-f46303604524248590a05ace7999fc60bac290d68e7430ae9da4a38f7784d191L191-R211) [[5]](diffhunk://#diff-f26846ad7bafc66bb3bc1a57596f82ed02966acd8bdab15afaee5fcfa536c4a2L23-R42).

**Address handling improvements:**

* Changed address, zip code, and city fields to be required strings (allowing empty values), both in DTOs and adapters, to standardize their handling and avoid undefined/null issues (`server/src/dto/tournament.dto.ts`, `server/src/adapters/tournament.adapter.ts`, `client/src/adapters/api.adapter.ts`) [[1]](diffhunk://#diff-017eab98f7afb91a8d32e3ec52566d6386a3991f735c6ee57e2c382b035eb151L26-R43) [[2]](diffhunk://#diff-017eab98f7afb91a8d32e3ec52566d6386a3991f735c6ee57e2c382b035eb151L56-R66) [[3]](diffhunk://#diff-109adbffbe5d207ce9f5861c96bde3f77619ee21e1ef4251a2fc5bdb87be7835L15-R23) [[4]](diffhunk://#diff-a9390b8f48172bc4ba0aad724cc2b721a3ab7e8bb808ca4ec8bd70a2ea440fa3L78-R93).

* Added `getFullAddress` utility to build a properly formatted address string for display, and used it in the shared fight card component (`client/src/utils/string.utils.ts`, `client/src/components/fight-card/shared-fight-card.component.vue`) [[1]](diffhunk://#diff-e1286a2344fc54ba1b3de40013737f4a3c15e16cbf2e710d354591ca83e7f0f3R27-R39) [[2]](diffhunk://#diff-f26846ad7bafc66bb3bc1a57596f82ed02966acd8bdab15afaee5fcfa536c4a2R110) [[3]](diffhunk://#diff-f26846ad7bafc66bb3bc1a57596f82ed02966acd8bdab15afaee5fcfa536c4a2R121-R127).

**User interface and localization:**

* Updated the tournament add/edit form to include a textarea for additional info, with a notice about its use in exports (`client/src/components/tournament/tournament-add-offcanvas.component.vue`).

* Updated localization files to add translations for the additional info field and its export notice (`client/src/locales/en-US.json`, `client/src/locales/fr-FR.json`) [[1]](diffhunk://#diff-816bb4380aa93aeca09643d55a0bdbf2267a990978f11caede416d210881740aR247-R248) [[2]](diffhunk://#diff-816bb4380aa93aeca09643d55a0bdbf2267a990978f11caede416d210881740aL259-R262) [[3]](diffhunk://#diff-a030e9cda3c11da9bd4ef518b9de81c57a78be04eedf89095a5f6b1ad2ff267dR247) [[4]](diffhunk://#diff-a030e9cda3c11da9bd4ef518b9de81c57a78be04eedf89095a5f6b1ad2ff267dL259-R261).

**Shared fight card enhancements:**

* Displayed the tournament's full address as a clickable Google Maps link and showed the additional info in the shared fight card view (`client/src/components/fight-card/shared-fight-card.component.vue`).

**Validation and API consistency:**

* Updated validation rules for address fields and added `MinLength(0)` for zip code to ensure empty strings are accepted but not undefined (`server/src/dto/tournament.dto.ts`).